### PR TITLE
Add translation ETL workflow

### DIFF
--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,0 +1,17 @@
+name: Daily dispatcher
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Runs every day at midnight UTC
+
+jobs:
+  run-etl:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        branch: [staging]
+    uses: ./.github/workflows/run_translation.yml
+    with:
+      environment: ${{ matrix.branch }}

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -1,4 +1,4 @@
-name: Daily dispatcher
+name: Daily translation dispatcher
 
 on:
   pull_request:
@@ -7,11 +7,12 @@ on:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
 
 jobs:
-  run-etl:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: [staging]
+  staging:
     uses: ./.github/workflows/run_translation.yml
     with:
-      environment: ${{ matrix.branch }}
+      environment: staging
+
+  production:
+    uses: ./.github/workflows/run_translation.yml
+    with:
+      environment: production

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/run_translation.yml
     with:
       environment: staging
+    secrets: inherit
 
   # production:
   #   uses: ./.github/workflows/run_translation.yml

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -17,3 +17,4 @@ jobs:
   #   uses: ./.github/workflows/run_translation.yml
   #   with:
   #     environment: production
+  #   secrets: inherit

--- a/.github/workflows/daily_scheduler.yml
+++ b/.github/workflows/daily_scheduler.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       environment: staging
 
-  production:
-    uses: ./.github/workflows/run_translation.yml
-    with:
-      environment: production
+  # production:
+  #   uses: ./.github/workflows/run_translation.yml
+  #   with:
+  #     environment: production

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: staging
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
@@ -40,7 +40,7 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: staging
     strategy:
       matrix:
         language: [spanish]

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,6 +1,7 @@
 name: Run translation ETL
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -31,7 +31,7 @@ jobs:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run batch extract
         run: python manage.py batch_extract
@@ -47,7 +47,7 @@ jobs:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run batch translation
         run: python manage.py batch_translate ${{ matrix.language }}
@@ -60,7 +60,7 @@ jobs:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Convert docs
         run: python manage.py convert_docs

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,11 +1,16 @@
 name: Run translation ETL
 
 on:
-  pull_request:
-    branches:
-      - main
-
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        default: staging
+        options:
+          - staging
+          - production
 
 env:
   DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
@@ -19,16 +24,11 @@ env:
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
 
 jobs:
-  etl:
+  extract:
     runs-on: ubuntu-latest
-    # environment: ${{ startsWith(github.ref, 'refs/heads/main') && 'staging' || startsWith(github.ref, 'refs/heads/deploy/') && 'production' }}
-    environment: staging
+    environment: ${{ github.event.inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:main
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,8 +36,31 @@ jobs:
       - name: Run batch extract
         run: python manage.py batch_extract
 
+  translate:
+    needs: extract
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    strategy:
+      matrix:
+        language: [spanish]
+    container:
+      image: ghcr.io/datamade/la-metro-translations:main
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Run batch translation
-        run: python manage.py batch_translate spanish
+        run: python manage.py batch_translate ${{ matrix.language }}
+
+  convert:
+    needs: translate
+    runs-on: ubuntu-latest
+    environment: staging
+    container:
+      image: ${{ github.event.inputs.environment }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Convert docs
         run: python manage.py convert_docs

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -12,6 +12,11 @@ on:
           - staging
           - production
 
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+
 env:
   DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,7 +1,6 @@
 name: Run translation ETL
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       environment:
@@ -27,7 +26,7 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.event.inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
@@ -40,7 +39,7 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.event.inputs.environment }}
     strategy:
       matrix:
         language: [spanish]
@@ -56,7 +55,7 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ github.event.inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:main
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       matrix:
         language: [spanish]
     container:
-      image: ghcr.io/datamade/la-metro-translations:main
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging
     container:
-      image: ${{ github.event.inputs.environment }}
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,0 +1,43 @@
+name: Run translation ETL
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+env:
+  DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_STORAGE_BUCKET_NAME: ${{ secrets.AWS_STORAGE_BUCKET_NAME }}
+  MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+  BOARDAGENDAS_API_KEY: ${{ secrets.BOARDAGENDAS_API_KEY }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  DJANGO_DEBUG: $${ vars.DJANGO_DEBUG }}
+  BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
+
+jobs:
+  etl:
+    runs-on: ubuntu-latest
+    # environment: ${{ startsWith(github.ref, 'refs/heads/main') && 'staging' || startsWith(github.ref, 'refs/heads/deploy/') && 'production' }}
+    environment: staging
+    container:
+      image: ghcr.io/datamade/la-metro-translations:main
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run batch extract
+        run: python manage.py batch_extract
+
+      - name: Run batch translation
+        run: python manage.py batch_translate spanish
+
+      - name: Convert docs
+        run: python manage.py convert_docs

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,21 +1,11 @@
 name: Run translation ETL
 
 on:
-  workflow_dispatch:
-    inputs:
-      environment:
-        description: "Deployment environment"
-        required: true
-        type: choice
-        default: staging
-        options:
-          - staging
-          - production
-
   workflow_call:
     inputs:
       environment:
         type: string
+        required: true
 
 env:
   DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
@@ -31,7 +21,8 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: staging
+    environment:
+      name: ${{ inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -29,7 +29,7 @@ env:
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
   # Get correct deployment environment whether this workflow was called
   # manually for from another workflow
-  DEPLOY_ENV: ${{ coalesce(fromJson(toJson(github.event.workflow_call.inputs)).environment, github.event.inputs.environment) }}
+  DEPLOY_ENV: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
 
 jobs:
   extract:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Check environment
-        run: |
-          echo "ENVIRONMENT:"
-          echo "${{ inputs.environment || workflow_call.inputs.environment }}"
-
       - name: Run batch extract
         run: python manage.py batch_extract
 

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -31,12 +31,18 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Check environment
+        run: |
+          echo "ENVIRONMENT:"
+          echo "${{ inputs.environment || workflow_call.inputs.environment }}"
 
       - name: Run batch extract
         run: python manage.py batch_extract
@@ -44,7 +50,8 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
     strategy:
       matrix:
         language: [spanish]
@@ -60,7 +67,8 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment:
+      name: ${{ inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -32,8 +32,7 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
@@ -46,8 +45,7 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
     strategy:
       matrix:
         language: [spanish]
@@ -63,8 +61,7 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -32,53 +32,51 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
 
-  # extract:
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: ${{ inputs.environment }}
-  #   container:
-  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v5
-  #
-  #     - name: Run batch extract
-  #       run: python manage.py batch_extract
-  #
-  # translate:
-  #   needs: extract
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: ${{ inputs.environment }}
-  #   strategy:
-  #     matrix:
-  #       language: [spanish]
-  #   container:
-  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v5
-  #
-  #     - name: Run batch translation
-  #       run: python manage.py batch_translate ${{ matrix.language }}
-  #
-  # convert:
-  #   needs: translate
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: ${{ inputs.environment }}
-  #   container:
-  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v5
-  #
-  #     - name: Convert docs
-  #       run: python manage.py convert_docs
+  extract:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    container:
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run batch extract
+        run: python manage.py batch_extract
+
+  translate:
+    needs: extract
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    strategy:
+      matrix:
+        language: [spanish]
+    container:
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run batch translation
+        run: python manage.py batch_translate ${{ matrix.language }}
+
+  convert:
+    needs: translate
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
+    container:
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Convert docs
+        run: python manage.py convert_docs

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -27,13 +27,16 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   DJANGO_DEBUG: $${ vars.DJANGO_DEBUG }}
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
+  # Get correct deployment environment whether this workflow was called
+  # manually for from another workflow
+  DEPLOY_ENV: ${{ coalesce(fromJson(toJson(github.event.workflow_call.inputs))?.environment, github.event.inputs.environment) }}
 
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ env.DEPLOY_ENV }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -44,12 +47,12 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ env.DEPLOY_ENV }}
     strategy:
       matrix:
         language: [spanish]
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -60,9 +63,9 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ env.DEPLOY_ENV }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -31,9 +31,9 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
+    environment: ${{ inputs.environment }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -44,12 +44,12 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
+    environment: ${{ inputs.environment }}
     strategy:
       matrix:
         language: [spanish]
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -60,9 +60,9 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
+    environment: ${{ inputs.environment }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -27,16 +27,13 @@ env:
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   DJANGO_DEBUG: $${ vars.DJANGO_DEBUG }}
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
-  # Get correct deployment environment whether this workflow was called
-  # manually for from another workflow
-  DEPLOY_ENV: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
 
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment: ${{ env.DEPLOY_ENV }}
+    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -47,12 +44,12 @@ jobs:
   translate:
     needs: extract
     runs-on: ubuntu-latest
-    environment: ${{ env.DEPLOY_ENV }}
+    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
     strategy:
       matrix:
         language: [spanish]
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -63,9 +60,9 @@ jobs:
   convert:
     needs: translate
     runs-on: ubuntu-latest
-    environment: ${{ env.DEPLOY_ENV }}
+    environment: ${{ github.event.inputs.environment || github.event.workflow_call.inputs.environment }}
     container:
-      image: ghcr.io/datamade/la-metro-translations:${{ env.DEPLOY_ENV == 'production' && 'deploy' || 'main' }}
+      image: ghcr.io/datamade/la-metro-translations:${{ github.event.inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -29,7 +29,7 @@ env:
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
   # Get correct deployment environment whether this workflow was called
   # manually for from another workflow
-  DEPLOY_ENV: ${{ coalesce(fromJson(toJson(github.event.workflow_call.inputs))?.environment, github.event.inputs.environment) }}
+  DEPLOY_ENV: ${{ coalesce(fromJson(toJson(github.event.workflow_call.inputs)).environment, github.event.inputs.environment) }}
 
 jobs:
   extract:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -31,8 +31,7 @@ env:
 jobs:
   extract:
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
+    environment: staging
     container:
       image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -30,13 +30,6 @@ env:
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
   extract:
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/run_translation.yml
+++ b/.github/workflows/run_translation.yml
@@ -1,6 +1,17 @@
 name: Run translation ETL
 
 on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        default: staging
+        options:
+          - staging
+          - production
+
   workflow_call:
     inputs:
       environment:
@@ -19,46 +30,55 @@ env:
   BOARDAGENDAS_URL: $${ vars.BOARDAGENDAS_URL }}
 
 jobs:
-  extract:
+  test:
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}
-    container:
-      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v4
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
-      - name: Run batch extract
-        run: python manage.py batch_extract
-
-  translate:
-    needs: extract
-    runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
-    strategy:
-      matrix:
-        language: [spanish]
-    container:
-      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Run batch translation
-        run: python manage.py batch_translate ${{ matrix.language }}
-
-  convert:
-    needs: translate
-    runs-on: ubuntu-latest
-    environment:
-      name: ${{ inputs.environment }}
-    container:
-      image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Convert docs
-        run: python manage.py convert_docs
+  # extract:
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: ${{ inputs.environment }}
+  #   container:
+  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v5
+  #
+  #     - name: Run batch extract
+  #       run: python manage.py batch_extract
+  #
+  # translate:
+  #   needs: extract
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: ${{ inputs.environment }}
+  #   strategy:
+  #     matrix:
+  #       language: [spanish]
+  #   container:
+  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v5
+  #
+  #     - name: Run batch translation
+  #       run: python manage.py batch_translate ${{ matrix.language }}
+  #
+  # convert:
+  #   needs: translate
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: ${{ inputs.environment }}
+  #   container:
+  #     image: ghcr.io/datamade/la-metro-translations:${{ inputs.environment == 'production' && 'deploy' || 'main' }}
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v5
+  #
+  #     - name: Convert docs
+  #       run: python manage.py convert_docs


### PR DESCRIPTION
## Overview

This PR adds Github Actions workflows to run our translation ETL on staging. It 

It uses two workflows: 

- the actual translation ETL logic that can be run manually on staging or production and should vary the image tag it pulls based on the selected environment
- a scheduler that will trigger the ETL on a schedule (currently once per day)

The translation workflow uses a matrix to run translations for any number of languages before running the `convert_docs` step. Currently, it'll just run Spanish.

When we're ready to run the production app on a schedule, we can uncomment that part of the scheduler.

Connects #19 

## Testing Instructions

- See [this run](https://github.com/datamade/la-metro-translations/actions/runs/25215918953/job/73936169792?pr=32) for a successful execution
