### PR TITLE
Ensure incoming document urls use https

### DIFF
--- a/la_metro_translations/api/serializers.py
+++ b/la_metro_translations/api/serializers.py
@@ -33,6 +33,12 @@ class DocumentSerializer(serializers.ModelSerializer):
             if not isinstance(v, UniqueTogetherValidator)
         ]
 
+    def validate_source_url(self, value):
+        # Mistral requires documents to start with https
+        if value.startswith("http://"):
+            return value.replace("http://", "https://", 1)
+        return value
+
 
 class NotificationSerializer(serializers.Serializer):
     """


### PR DESCRIPTION
## Overview

A handful of documents from 2019 and earlier had urls starting with `http` instead of `https`. Mistral requires for documents to start with https before OCRing. This pr adjusts the urls for the problem docs, since they actually get autocorrected that way when tested in the browser.

[Check out the failing action here](https://github.com/datamade/la-metro-translations/actions/runs/25557750945/job/75020987229#step:4:33).

### Notes

The failing check on this pr is unrelated to these changes, and is being resolved in another pr!

## Testing Instructions
<details markdown='1'>
  <summary>
    <strong>Note</strong>: Click to show a sample payload you can send to the review app
  </summary>
  <pre><code>
{
    "api_key": "review_app_test_key",
    "documents": [
        {
            "document_id": "123",
            "title": "2025-0945 - COUNTYWIDE PLANNING MAJOR PROJECT STATUS REPORT",
            "source_url": "http://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=11963&GUID=LATEST&Title=Board+Report",
            "created_at": "2026-01-14",
            "updated_at": "2026-01-14",
            "document_type": "bill_document",
            "entity_type": "bill",
            "entity_id": "456"
        },
        {
            "document_id": "789",
            "title": "2026-0035 - METRO GOVERNANCE REVIEW MOTION",
            "source_url": "http://metro.legistar.com/ViewReport.ashx?M=R&N=TextL5&GID=557&ID=12151&GUID=LATEST&Title=Board+Report",
            "created_at": "2026-01-15",
            "updated_at": "2026-01-15",
            "document_type": "bill_document",
            "entity_type": "bill",
            "entity_id": "101"
        },
        {
            "document_id": "321",
            "title": "Planning and Programming Committee",
            "source_url": "https://metro.legistar1.com/metro/meetings/2026/1/3218_A_Planning_and_Programming_Committee_26-01-14_Agenda.pdf",
            "created_at": "2026-01-14",
            "updated_at": "2026-01-14",
            "document_type": "event_document",
            "entity_type": "event",
            "entity_id": "654"
        }
    ]
}
  </code></pre>
</details>

- Make an api request to the review app's notification endpoint, featuring source_urls starting with `http://`
  - `https://la-metro-tra-patch-clea-www0ib.herokuapp.com/api/update-documents/`
  - I recommend postman for ease of use, but send it however you like
- Log in to the review app using the creds in bitwarden titled "Metro Translations - Review app" and check out the source urls for your new Documents
  - Can hover over the "View Original Document" button in the list
  - Confirm that all of your notified docs have been adjusted to start with `https://`
  - Confirm links still work
