### PR TITLE
Add try/except blocks to doc conversion

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,3 +7,5 @@ exclude =
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
 max-line-length = 88
 extend-ignore = E203 E231 E702
+per-file-ignores =
+    */__init__.py: F401

--- a/la_metro_translations/management/commands/convert_docs.py
+++ b/la_metro_translations/management/commands/convert_docs.py
@@ -4,7 +4,10 @@ from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery
 
 from la_metro_translations.models import DocumentTranslation, TranslationFile
-from la_metro_translations.services import DocumentTranslationConverter
+from la_metro_translations.services import (
+    DocumentTranslationConverter,
+    DocumentTranslationConverterError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -28,14 +31,19 @@ class Command(BaseCommand):
         eng_rtfs_to_create = DocumentTranslation.objects.filter(language="en").exclude(
             pk__in=Subquery(up_to_date_rtfs.values("document_translation"))
         )
-        for doc in eng_rtfs_to_create:
-            files_to_create.append(DocumentTranslationConverter(doc).convert_to_rtf())
 
         non_eng_rtfs_to_create = DocumentTranslation.objects.exclude(
             language="en"
         ).exclude(pk__in=Subquery(up_to_date_rtfs.values("document_translation")))
-        for doc in non_eng_rtfs_to_create:
-            files_to_create.append(DocumentTranslationConverter(doc).convert_to_rtf())
+
+        all_rtfs_to_create = eng_rtfs_to_create.union(non_eng_rtfs_to_create)
+        for doc in all_rtfs_to_create:
+            try:
+                rtf_file = DocumentTranslationConverter(doc).convert_to_rtf()
+            except DocumentTranslationConverterError as e:
+                logger.error(f"Error while converting {doc}: {e}")
+            else:
+                files_to_create.append(rtf_file)
 
         # Create PDFs
         up_to_date_pdfs = TranslationFile.objects.filter(
@@ -48,10 +56,15 @@ class Command(BaseCommand):
             language="en"
         ).exclude(pk__in=Subquery(up_to_date_pdfs.values("document_translation")))
         for doc in non_eng_pdfs_to_create:
-            files_to_create.append(DocumentTranslationConverter(doc).convert_to_pdf())
+            try:
+                pdf_file = DocumentTranslationConverter(doc).convert_to_pdf()
+            except DocumentTranslationConverterError as e:
+                logger.error(f"Error while converting {doc}: {e}")
+            else:
+                files_to_create.append(pdf_file)
 
         if not files_to_create:
-            logger.info("All translations have up to date rtfs and pdfs!")
+            logger.info("All translations have up to date RTFs and PDFs!")
             return
 
         for file in files_to_create:

--- a/la_metro_translations/management/commands/convert_docs.py
+++ b/la_metro_translations/management/commands/convert_docs.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
             try:
                 rtf_file = DocumentTranslationConverter(doc).convert_to_rtf()
             except DocumentTranslationConverterError as e:
-                logger.error(f"Error while converting {doc}: {e}")
+                logger.error(f"Error while converting {doc} to RTF: {e}")
             else:
                 files_to_create.append(rtf_file)
 
@@ -59,7 +59,7 @@ class Command(BaseCommand):
             try:
                 pdf_file = DocumentTranslationConverter(doc).convert_to_pdf()
             except DocumentTranslationConverterError as e:
-                logger.error(f"Error while converting {doc}: {e}")
+                logger.error(f"Error while converting {doc} to PDF: {e}")
             else:
                 files_to_create.append(pdf_file)
 

--- a/la_metro_translations/services/__init__.py
+++ b/la_metro_translations/services/__init__.py
@@ -1,3 +1,6 @@
-from .conversion import DocumentTranslationConverter  # noqa
-from .ocr import MistralOCRService  # noqa
-from .translation import MistralTranslationService  # noqa
+from .conversion import (
+    DocumentTranslationConverter,
+    DocumentTranslationConverterError,
+)
+from .ocr import MistralOCRService
+from .translation import MistralTranslationService


### PR DESCRIPTION
## Overview

See title.

Doesn't fix the pandoc error during conversion but should allow the conversion action to run for docs that don't throw that error.

Connects #36