### PR TITLE
Display links to files in admin

### DIFF
--- a/la_metro_translations/models.py
+++ b/la_metro_translations/models.py
@@ -255,6 +255,30 @@ class DocumentContent(AdminDisplayMixin, models.Model):
 
     document_title.short_description = "Title"
 
+    def file_formats_display(self):
+        files_btn_fragment = (
+            "<a class='button'"
+            "style='width: stretch; font-weight: bold; text-align: center;'"
+            "target='_blank' href='{}'>{}</a>"
+        )
+        files_btns = files_btn_fragment.format(self.document.source_url, "Original PDF")
+
+        try:
+            rtf = self.translations.get(language="en").files.get(format="rtf")
+        except (DocumentTranslation.DoesNotExist, TranslationFile.DoesNotExist):
+            pass
+        else:
+            files_btns += files_btn_fragment.format(
+                rtf.get_file_url(), rtf.format.upper()
+            )
+
+        return format_html(
+            "<div style='display: flex; justify-content: space-between'>{}</div>",
+            mark_safe(files_btns),
+        )
+
+    file_formats_display.short_description = "File Formats"
+
 
 class DocumentTranslation(AdminDisplayMixin, models.Model):
     """

--- a/la_metro_translations/models.py
+++ b/la_metro_translations/models.py
@@ -460,7 +460,7 @@ class TranslationFile(models.Model):
         if self.format == "pdf" and self.document_translation.language == "en":
             return self.document_translation.document_content.document.source_url
 
-        return self.file
+        return self.file.url
 
 
 class ExtractionConfig(BaseGenericSetting, ClusterableModel):

--- a/la_metro_translations/models.py
+++ b/la_metro_translations/models.py
@@ -355,6 +355,27 @@ class DocumentTranslation(AdminDisplayMixin, models.Model):
 
     language_display.short_description = "Language"
 
+    def file_formats_display(self):
+        if getattr(self, "files", False):
+            files_btns = ""
+            for f in self.files.all():
+                files_btns += (
+                    "<a class='button'"
+                    "style='width: stretch; font-weight: bold; text-align: center;'"
+                    f"target='_blank' href='{f.get_file_url()}'>{f.format.upper()}</a>"
+                )
+
+            return format_html(
+                "<div style='display: flex; justify-content: space-between'>{}</div>",
+                mark_safe(files_btns),
+            )
+
+        return mark_safe(
+            "<p>This translation is not yet available in other file formats.</p>"
+        )
+
+    file_formats_display.short_description = "File Formats"
+
 
 def translation_file_path(instance, filename):
     year = instance.document_translation.document_content.document.created_at.year
@@ -411,7 +432,7 @@ class TranslationFile(models.Model):
         self.file.delete(save=False)
         super().delete()
 
-    def get_file(self):
+    def get_file_url(self):
         if self.format == "pdf" and self.document_translation.language == "en":
             return self.document_translation.document_content.document.source_url
 

--- a/la_metro_translations/wagtail_hooks.py
+++ b/la_metro_translations/wagtail_hooks.py
@@ -204,7 +204,16 @@ class DocumentContentViewSet(ModelViewSet):
                         FieldPanel("updated_at", read_only=True),
                     ]
                 ),
-                FieldPanel("approval_status"),
+                FieldRowPanel(
+                    [
+                        FieldPanel("approval_status"),
+                        PropertyPanel(
+                            "file_formats_display",
+                            heading="File Formats",
+                            attrs={"style": "width: stretch;"},
+                        ),
+                    ]
+                ),
                 FieldPanel("markdown"),
             ],
             heading="Document Content",

--- a/la_metro_translations/wagtail_hooks.py
+++ b/la_metro_translations/wagtail_hooks.py
@@ -354,7 +354,16 @@ class DocumentTranslationViewSet(ModelViewSet):
                         FieldPanel("updated_at", read_only=True),
                     ]
                 ),
-                FieldPanel("approval_status"),
+                FieldRowPanel(
+                    [
+                        FieldPanel("approval_status"),
+                        PropertyPanel(
+                            "file_formats_display",
+                            heading="File Formats",
+                            attrs={"style": "width: stretch;"},
+                        ),
+                    ]
+                ),
                 FieldPanel("markdown"),
             ],
             heading="Document Translation",


### PR DESCRIPTION
## Overview

This pr adds links on each content and translation's detail page, that lead to any uploaded files for that object if they are available. If none are available, a message will show up explaining so.

`DocumentTranslations` other than english will have links to pdfs and rtfs that we generate.

`DocumentContents` and english `DocumentTranslations` will have a link to rtfs that we generate, and another to the original pdfs found on legistar (since we don't generate english pdfs)

- Closes #42 

### Demo
<img width="1095" height="617" alt="image" src="https://github.com/user-attachments/assets/84bab535-c8dc-4089-859e-c4d7ba4652a5" />

### Notes
The review app already has some extra documents that have all been processed.

## Testing Instructions

- Log in to the review app using the credentials in Bitwarden titled "Metro Translations - Review app"
- Check out a few contents and translations
  - Confirm that they all have links to different file formats, and that those links work.
