### PR TITLE
View prompt in Wagtail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         exclude: ^(la_metro_translations/migrations/)
 
   - repo: https://github.com/pycqa/flake8
-    rev: "9f60881"
+    rev: "c48217e1"
     hooks:
       - id: flake8
         exclude: la_metro_translations/migrations

--- a/la_metro_translations/templates/la_metro_translations/prompt.html
+++ b/la_metro_translations/templates/la_metro_translations/prompt.html
@@ -1,0 +1,9 @@
+{% extends "wagtailadmin/base.html" %}
+{% load static %}
+
+{% block content %}
+  {% include "wagtailadmin/shared/header.html" with title="Prompt" icon="openquote" %}
+  <main class="nice-padding">
+    <p style="font-size:125%" >{{ prompt_text }}</p>
+  </main>
+{% endblock %}

--- a/la_metro_translations/views.py
+++ b/la_metro_translations/views.py
@@ -1,6 +1,20 @@
 import os
-
+from django.conf import settings
 from django.shortcuts import render
+from django.views.generic import TemplateView
+
+
+class PromptView(TemplateView):
+    template_name = "la_metro_translations/prompt.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        file_path = os.path.join(
+            settings.BASE_DIR, "la_metro_translations", "prompt.txt"
+        )
+        with open(file_path) as f:
+            context["prompt_text"] = f.read()
+        return context
 
 
 def robots_txt(request):

--- a/la_metro_translations/wagtail_hooks.py
+++ b/la_metro_translations/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from wagtail import hooks
+from wagtail.admin.menu import MenuItem
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel, FieldRowPanel
 from wagtail.admin.viewsets.model import ModelViewSet
 from wagtail.admin.filters import WagtailFilterSet
@@ -7,11 +8,11 @@ from wagtail.permissions import ModelPermissionPolicy
 from wagtail.snippets.views.snippets import IndexView
 
 from django_filters import CharFilter, ChoiceFilter
+from django.urls import path, reverse
+from .views import PromptView
 
 from .models import Document, DocumentContent, DocumentTranslation, ExtractionConfig
 from .panels import PropertyPanel, RelatedObjectsPanel
-
-register_setting(ExtractionConfig, icon="cog")
 
 
 class ReadEditOnlyPermissionPolicy(ModelPermissionPolicy):
@@ -377,6 +378,23 @@ def register_document_translation_viewset():
     return DocumentTranslationViewSet("document_translation")
 
 
+@hooks.register("register_admin_urls")
+def register_prompt_url():
+    return [
+        path("prompt/", PromptView.as_view(), name="prompt"),
+    ]
+
+
+# Custom settings items, put at top of list (order before 100)
+register_setting(ExtractionConfig, icon="cog", order=50)
+
+
+@hooks.register("register_settings_menu_item")
+def register_prompt_menu_item():
+    return MenuItem("Prompt", reverse("prompt"), icon_name="openquote", order=51)
+
+
+# Only show selected elements in main menu
 @hooks.register("construct_main_menu")
 def hide_all_but_modeladmin_and_settings(request, menu_items):
     signatures = (


### PR DESCRIPTION
## Overview

Allows users to view prompt in Wagtail

Connects to #28 

### Demo

<img width="897" height="659" alt="Screenshot 2026-06-03 at 4 13 55 PM" src="https://github.com/user-attachments/assets/ce0d7094-8c1b-4a94-b45f-97e2938d6387" />


### Notes

Per sprint planning discussion, this only adds the ability to view the prompt, and not to modify it.

## Testing Instructions

- Log into Wagtail
- You should see Prompt in the sidebar
- When you click it, you should see the same text as in `prompt.txt` in this repo
