### PR TITLE
Give boardagendas links to files

### DIFF
--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 from django.db.models import Prefetch
+from django.db.models import Case, When
+
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
@@ -95,10 +97,29 @@ class DocumentFilesView(APIView):
             agenda_text_map if entity_type == "event" else board_report_text_map
         )
 
+        lang_order = [
+            "eng",
+            "spa",
+            "zho-cn",
+            "zho-tw",
+            "kor",
+            "hye",
+            "hyw",
+            "vie",
+            "rus",
+            "jpn",
+        ]
+        ordered = Case(
+            *[
+                When(language=language, then=index)
+                for index, language in enumerate(lang_order)
+            ]
+        )
+
         # Only return relevant related objects
         translation_filter = DocumentTranslation.objects.filter(
             approval_status="approved"
-        )
+        ).order_by(ordered)
         files_filter = TranslationFile.objects.exclude(
             document_translation__language="eng", format="pdf"
         )
@@ -118,10 +139,6 @@ class DocumentFilesView(APIView):
                     "link_text": link_text_map[translation.language],
                     "url": file.get_file_url(),
                 }
-                if translation.language == "eng" and file.format == "rtf":
-                    # Put english rtf at beginning of list
-                    file_links[file.format].insert(0, link_details)
-                else:
-                    file_links[file.format].append(link_details)
+                file_links[file.format].append(link_details)
 
         return Response(file_links, status=status.HTTP_200_OK)

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -56,18 +56,34 @@ class DocumentFilesView(APIView):
         api_key = request.query_params.get("api_key")
         entity_type = request.query_params.get("entity_type")
         document_id = request.query_params.get("document_id")
-        link_text_map = {
+        agenda_text_map = {
             "hye": "Օրակարգը ներբեռնել (Արևելահայերեն)",
             "hyw": "Ներբեռնել Օրակարգը (Արևմտահայերէն)",
             "zho-cn": "下载议程 (汉语)",
             "zho-tw": "下載議程 (漢語)",
             "eng": "Download Agenda (English)",
-            "jpn": "議事日程のダウンロード (日本語)",
+            "jpn": "議題をダウンロード (日本語)",
             "kor": "의제 다운로드 (한국어)",
             "rus": "Скачать повестку дня (Русский)",
             "spa": "Descargar Agenda (Español)",
             "vie": "Tải xuống Chương trình (tiếng Việt)",
         }
+        board_report_text_map = {
+            "hye": "Download Board Report (Արևելահայերեն)",
+            "hyw": "Download Board Report (Արևմտահայերէն)",
+            "zho-cn": "Download Board Report (汉语)",
+            "zho-tw": "Download Board Report (漢語)",
+            "eng": "Download Board Report (English)",
+            "jpn": "Download Board Report (日本語)",
+            "kor": "Download Board Report (한국어)",
+            "rus": "Download Board Report (Русский)",
+            "spa": "Download Board Report (Español)",
+            "vie": "Download Board Report (tiếng Việt)",
+        }
+
+        link_text_map = (
+            agenda_text_map if entity_type == "event" else board_report_text_map
+        )
 
         if api_key != settings.BOARDAGENDAS_API_KEY:
             error_msg = "Unauthorized: Invalid api key. Double check the key submitted."
@@ -85,12 +101,17 @@ class DocumentFilesView(APIView):
         for translation in content.translations.all():
             for file in translation.files.all():
                 if translation.language == "eng" and file.format == "pdf":
+                    # Don't bother with english pdf
                     continue
-                file_links[file.format].append(
-                    {
-                        "link_text": link_text_map[translation.language],
-                        "url": file.get_file_url(),
-                    }
-                )
+
+                link_details = {
+                    "link_text": link_text_map[translation.language],
+                    "url": file.get_file_url(),
+                }
+                if translation.language == "eng" and file.format == "rtf":
+                    # Put english rtf at beginning of list
+                    file_links[file.format].insert(0, link_details)
+                else:
+                    file_links[file.format].append(link_details)
 
         return Response(file_links, status=status.HTTP_200_OK)

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -1,9 +1,15 @@
 from django.conf import settings
+from django.db.models import Prefetch
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 
-from la_metro_translations.models import Document, DocumentContent
+from la_metro_translations.models import (
+    Document,
+    DocumentContent,
+    DocumentTranslation,
+    TranslationFile,
+)
 from la_metro_translations.api.serializers import NotificationSerializer
 
 
@@ -89,9 +95,17 @@ class DocumentFilesView(APIView):
             agenda_text_map if entity_type == "event" else board_report_text_map
         )
 
+        # Only return relevant related objects
+        translation_filter = DocumentTranslation.objects.filter(
+            approval_status="approved"
+        )
+        files_filter = TranslationFile.objects.exclude(
+            document_translation__language="eng", format="pdf"
+        )
         try:
             content = DocumentContent.objects.prefetch_related(
-                "translations", "translations__files"
+                Prefetch("translations", translation_filter),
+                Prefetch("translations__files", files_filter),
             ).get(document__entity_type=entity_type, document__document_id=document_id)
         except DocumentContent.DoesNotExist:
             error_msg = "Not Found: Matching document does not exist in the suite."
@@ -99,15 +113,7 @@ class DocumentFilesView(APIView):
 
         file_links = {"pdf": [], "rtf": []}
         for translation in content.translations.all():
-            # Only return approved translations
-            if translation.approval_status != "approved":
-                continue
-
             for file in translation.files.all():
-                if translation.language == "eng" and file.format == "pdf":
-                    # Don't bother with english pdf
-                    continue
-
                 link_details = {
                     "link_text": link_text_map[translation.language],
                     "url": file.get_file_url(),

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -99,6 +99,10 @@ class DocumentFilesView(APIView):
 
         file_links = {"pdf": [], "rtf": []}
         for translation in content.translations.all():
+            # Only return approved translations
+            if translation.approval_status != "approved":
+                continue
+
             for file in translation.files.all():
                 if translation.language == "eng" and file.format == "pdf":
                     # Don't bother with english pdf

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -1,8 +1,9 @@
+from django.conf import settings
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 
-from la_metro_translations.models import Document
+from la_metro_translations.models import Document, DocumentContent
 from la_metro_translations.api.serializers import NotificationSerializer
 
 
@@ -44,3 +45,52 @@ class DocumentUpdateView(APIView):
             "message": f"Success: Document(s) created/updated - {len(created_docs)}"
         }
         return Response(success_msg, status=status.HTTP_201_CREATED)
+
+
+class DocumentFilesView(APIView):
+    """
+    Return urls for an entity's files and translations.
+    """
+
+    def get(self, request):
+        api_key = request.query_params.get("api_key")
+        entity_type = request.query_params.get("entity_type")
+        entity_id = request.query_params.get("entity_id")
+        link_text_map = {
+            "hye": "Օրակարգը ներբեռնել (Արևելահայերեն)",
+            "hyw": "Ներբեռնել Օրակարգը (Արևմտահայերէն)",
+            "zho-cn": "下载议程 (汉语)",
+            "zho-tw": "下載議程 (漢語)",
+            "eng": "Download Agenda (English)",
+            "jpn": "議事日程のダウンロード (日本語)",
+            "kor": "의제 다운로드 (한국어)",
+            "rus": "Скачать повестку дня (Русский)",
+            "spa": "Descargar Agenda (Español)",
+            "vie": "Tải xuống Chương trình (tiếng Việt)",
+        }
+
+        if api_key != settings.BOARDAGENDAS_API_KEY:
+            error_msg = "Unauthorized: Invalid api key. Double check the key submitted."
+            return Response(error_msg, status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            content = DocumentContent.objects.prefetch_related(
+                "translations", "translations__files"
+            ).get(document__entity_type=entity_type, document__entity_id=entity_id)
+        except DocumentContent.DoesNotExist:
+            error_msg = "Not Found: Matching document does not exist in the suite."
+            return Response(error_msg, status=status.HTTP_404_NOT_FOUND)
+
+        file_links = {"pdf": [], "rtf": []}
+        for translation in content.translations.all():
+            for file in translation.files.all():
+                if translation.language == "eng" and file.format == "pdf":
+                    continue
+                file_links[file.format].append(
+                    {
+                        "link_text": link_text_map[translation.language],
+                        "url": file.get_file_url(),
+                    }
+                )
+
+        return Response(file_links, status=status.HTTP_200_OK)

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -54,6 +54,10 @@ class DocumentFilesView(APIView):
 
     def get(self, request):
         api_key = request.query_params.get("api_key")
+        if api_key != settings.BOARDAGENDAS_API_KEY:
+            error_msg = "Unauthorized: Invalid api key. Double check the key submitted."
+            return Response(error_msg, status=status.HTTP_403_FORBIDDEN)
+
         entity_type = request.query_params.get("entity_type")
         document_id = request.query_params.get("document_id")
         agenda_text_map = {
@@ -84,10 +88,6 @@ class DocumentFilesView(APIView):
         link_text_map = (
             agenda_text_map if entity_type == "event" else board_report_text_map
         )
-
-        if api_key != settings.BOARDAGENDAS_API_KEY:
-            error_msg = "Unauthorized: Invalid api key. Double check the key submitted."
-            return Response(error_msg, status=status.HTTP_403_FORBIDDEN)
 
         try:
             content = DocumentContent.objects.prefetch_related(

--- a/la_metro_translations/api/views.py
+++ b/la_metro_translations/api/views.py
@@ -55,7 +55,7 @@ class DocumentFilesView(APIView):
     def get(self, request):
         api_key = request.query_params.get("api_key")
         entity_type = request.query_params.get("entity_type")
-        entity_id = request.query_params.get("entity_id")
+        document_id = request.query_params.get("document_id")
         link_text_map = {
             "hye": "Օրակարգը ներբեռնել (Արևելահայերեն)",
             "hyw": "Ներբեռնել Օրակարգը (Արևմտահայերէն)",
@@ -76,7 +76,7 @@ class DocumentFilesView(APIView):
         try:
             content = DocumentContent.objects.prefetch_related(
                 "translations", "translations__files"
-            ).get(document__entity_type=entity_type, document__entity_id=entity_id)
+            ).get(document__entity_type=entity_type, document__document_id=document_id)
         except DocumentContent.DoesNotExist:
             error_msg = "Not Found: Matching document does not exist in the suite."
             return Response(error_msg, status=status.HTTP_404_NOT_FOUND)

--- a/la_metro_translations/urls.py
+++ b/la_metro_translations/urls.py
@@ -17,6 +17,11 @@ urlpatterns = [
         api_views.DocumentUpdateView.as_view(),
         name="update_documents",
     ),
+    path(
+        "api/document-files/",
+        api_views.DocumentFilesView.as_view(),
+        name="document_files",
+    ),
     path("robots.txt/", views.robots_txt),
     path("pages/", include(wagtail_urls)),
     path("", include(wagtailadmin_urls)),


### PR DESCRIPTION
## Overview

This pr adds a new webhook that BoardAgendas can use to check what files are available for agendas and board reports.

- Closes #10 

### Notes

This pr is meant to be tested/brought in with a [matching pr in councilmatic](https://github.com/Metro-Records/la-metro-councilmatic/pull/1311). Both review apps are set up to talk to each other. This pr's review app has also had staging's db copied into it as of 6/12/2026, so it should have plenty of documents to test with.

If you'd like to log in to this review app, you can use the bitwarden creds for translation suite staging.

## Testing Instructions

- Head to the corresponding [BoardAgendas review app](https://la-metro-cou-feat-show--xlm9tn.herokuapp.com/), and check out some past event and bill detail pages
  - Example with approved translations in [boardagendas](https://la-metro-cou-feat-show--xlm9tn.herokuapp.com/event/ad-hoc-board-composition-committee-914582fb4f35/) and in the [translation suite](https://la-metro-tra-feat-doc-u-ktpdzz.herokuapp.com/document/edit/1217/)
- Confirm that links to alternate files are displayed if available
- Confirm that links lead to the right agenda/board report, and for the right language described in the link text
- Confirm that the links that show up are only for published documents by looking for `Published` in the url.
