### PR TITLE
More conversion etl fixes/optimizations

### DIFF
--- a/la_metro_translations/management/commands/convert_docs.py
+++ b/la_metro_translations/management/commands/convert_docs.py
@@ -76,10 +76,13 @@ class Command(BaseCommand):
         )
 
         logger.info("Checking for translations that need up to date PDFs...")
-        pdf_qs = DocumentTranslation.objects.exclude(
-            pk__in=Subquery(up_to_date_pdfs.values("document_translation")),
-            language="eng",
-        ).select_related("document_content__document")
+        pdf_qs = (
+            DocumentTranslation.objects.exclude(
+                pk__in=Subquery(up_to_date_pdfs.values("document_translation"))
+            )
+            .exclude(language="eng")
+            .select_related("document_content__document")
+        )
         for doc in tqdm(pdf_qs.iterator(chunk_size=chunk_size), total=pdf_qs.count()):
             self.meter_files_in_memory(files_to_create, chunk_size)
             try:

--- a/la_metro_translations/management/commands/convert_docs.py
+++ b/la_metro_translations/management/commands/convert_docs.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime
 from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery
+from django.db import connections
 from tqdm import tqdm
 
 from la_metro_translations.models import DocumentTranslation, TranslationFile
@@ -23,6 +24,10 @@ class Command(BaseCommand):
             default=None,
             help="The ID of the document translation to convert.",
         )
+
+    def reset_db_connections(self):
+        for conn in connections.all():
+            conn.close_if_unusable_or_obsolete()
 
     def handle(self, *args, **options):
         """
@@ -96,6 +101,7 @@ class Command(BaseCommand):
             logger.info("All translations have up to date RTFs and PDFs!")
             return
 
+        self.reset_db_connections()
         self.bulk_create_translation_files(files_to_create)
 
         logger.info("--- Finished! ---")
@@ -120,5 +126,6 @@ class Command(BaseCommand):
         of files in memory. Prevents Heroku "memory quota vastly exceeded" errors.
         """
         if len(files_to_create) >= chunk_size:
+            self.reset_db_connections()
             self.bulk_create_translation_files(files_to_create)
             del files_to_create[:]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pip==25.3
 psycopg2-binary==2.9.11
 pytest==9.0.2
 pytest-django
+pytest-mock
 factory-boy
 sentry-sdk==2.49.0
 setuptools==80.9.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,20 @@ from django.contrib.auth.models import Permission, Group
 import factory
 import pytest
 
+from la_metro_translations.management.commands.convert_docs import (
+    Command as convert_docs_command,
+)
+
 from django.contrib.contenttypes.models import ContentType
 from la_metro_translations.models import (
     Document,
     DocumentContent,
     DocumentTranslation,
+)
+
+_PATCH_CONVERT_DOCS_CONVERTER = (
+    "la_metro_translations.management.commands.convert_docs"
+    ".DocumentTranslationConverter"
 )
 
 
@@ -134,6 +143,17 @@ def wagtail_user(django_user_model, wagtail_user_group):
     wagtail_user.groups.add(wagtail_user_group)
     wagtail_user.save()
     return wagtail_user, password
+
+
+@pytest.fixture
+def mock_converter(mocker):
+    bulk_create = mocker.patch.object(
+        convert_docs_command, "bulk_create_translation_files"
+    )
+    converter_cls = mocker.patch(_PATCH_CONVERT_DOCS_CONVERTER)
+    instance = converter_cls.return_value
+    instance.bulk_create = bulk_create
+    return instance
 
 
 @pytest.fixture

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,7 +1,7 @@
 import itertools
 import pytest
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.core.management import call_command as run_command
 
@@ -12,7 +12,6 @@ from conftest import (
     ExtractionConfigFactory,
     TranslationConfigFactory,
 )
-from la_metro_translations.management.commands.convert_docs import Command
 from la_metro_translations.models import (
     DocumentContent,
     DocumentTranslation,
@@ -36,11 +35,6 @@ PATCH_TRANSLATE_RESET_DB = (
 PATCH_EXTRACT_RESET_DB = (
     "la_metro_translations.management.commands.batch_extract"
     ".Command.reset_db_connections"
-)
-
-PATCH_CONVERT_DOCS_CONVERTER = (
-    "la_metro_translations.management.commands.convert_docs"
-    ".DocumentTranslationConverter"
 )
 
 PATCH_TRANSLATE_SERVICE = (
@@ -269,11 +263,8 @@ class TestConvertDocsCommand:
             TranslationFile.objects.filter(pk=file.pk).update(updated_at=updated_at)
         return file
 
-    def _mock_converter(self):
-        return patch(PATCH_CONVERT_DOCS_CONVERTER)
-
     def test_rtf_created_only_for_translations_without_up_to_date_rtf(
-        self, make_translation
+        self, make_translation, mock_converter
     ):
         """
         Only translations missing an RTF or with an outdated RTF (file.updated_at <
@@ -293,18 +284,12 @@ class TestConvertDocsCommand:
         self._set_updated_at(up_to_date, past)
         self._make_translation_file(up_to_date, "rtf", updated_at=now)
 
-        with self._mock_converter() as MockConverter, patch.object(
-            Command, "bulk_create_translation_files"
-        ):
-            mock_instance = MockConverter.return_value
-            mock_instance.convert_to_rtf.return_value = MagicMock()
-            mock_instance.convert_to_pdf.return_value = MagicMock()
-            run_command("convert_docs")
+        run_command("convert_docs")
 
-        assert mock_instance.convert_to_rtf.call_count == 2
+        assert mock_converter.convert_to_rtf.call_count == 2
 
     def test_pdf_created_only_for_non_english_translations_without_up_to_date_pdf(
-        self, make_translation
+        self, make_translation, mock_converter
     ):
         """
         PDFs should only be created for non-English translations that are missing a
@@ -330,17 +315,13 @@ class TestConvertDocsCommand:
         self._set_updated_at(up_to_date, past)
         self._make_translation_file(up_to_date, "pdf", updated_at=now)
 
-        with self._mock_converter() as MockConverter, patch.object(
-            Command, "bulk_create_translation_files"
-        ):
-            mock_instance = MockConverter.return_value
-            mock_instance.convert_to_rtf.return_value = MagicMock()
-            mock_instance.convert_to_pdf.return_value = MagicMock()
-            run_command("convert_docs")
+        run_command("convert_docs")
 
-        assert mock_instance.convert_to_pdf.call_count == 2
+        assert mock_converter.convert_to_pdf.call_count == 2
 
-    def test_no_files_created_when_all_are_up_to_date(self, make_translation):
+    def test_no_files_created_when_all_are_up_to_date(
+        self, make_translation, mock_converter
+    ):
         """
         When every translation already has a current RTF and PDF, no converter calls
         should be made and bulk_create should not be invoked.
@@ -357,18 +338,14 @@ class TestConvertDocsCommand:
         self._set_updated_at(eng, past)
         self._make_translation_file(eng, "rtf", updated_at=now)
 
-        with self._mock_converter() as MockConverter, patch.object(
-            Command, "bulk_create_translation_files"
-        ) as mock_bulk_create:
-            mock_instance = MockConverter.return_value
-            run_command("convert_docs")
+        run_command("convert_docs")
 
-        mock_instance.convert_to_rtf.assert_not_called()
-        mock_instance.convert_to_pdf.assert_not_called()
-        mock_bulk_create.assert_not_called()
+        mock_converter.convert_to_rtf.assert_not_called()
+        mock_converter.convert_to_pdf.assert_not_called()
+        mock_converter.bulk_create.assert_not_called()
 
     def test_convert_doc_single_creates_rtf_and_pdf_for_non_english(
-        self, make_translation
+        self, make_translation, mock_converter
     ):
         """
         When called with --document_translation <id> for a non-English translation,
@@ -376,13 +353,7 @@ class TestConvertDocsCommand:
         """
         translation = make_translation(language="spa")
 
-        with self._mock_converter() as MockConverter, patch.object(
-            Command, "bulk_create_translation_files"
-        ):
-            mock_instance = MockConverter.return_value
-            mock_instance.convert_to_rtf.return_value = MagicMock()
-            mock_instance.convert_to_pdf.return_value = MagicMock()
-            run_command("convert_docs", document_translation=translation.pk)
+        run_command("convert_docs", document_translation=translation.pk)
 
-        mock_instance.convert_to_rtf.assert_called_once()
-        mock_instance.convert_to_pdf.assert_called_once()
+        mock_converter.convert_to_rtf.assert_called_once()
+        mock_converter.convert_to_pdf.assert_called_once()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,15 +1,23 @@
+import itertools
 import pytest
-from unittest.mock import patch
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 from django.core.management import call_command as run_command
 
 from conftest import (
+    DocumentContentFactory,
     DocumentFactory,
     DocumentTranslationFactory,
     ExtractionConfigFactory,
     TranslationConfigFactory,
 )
-from la_metro_translations.models import DocumentContent, DocumentTranslation
+from la_metro_translations.management.commands.convert_docs import Command
+from la_metro_translations.models import (
+    DocumentContent,
+    DocumentTranslation,
+    TranslationFile,
+)
 
 PATCH_OCR = (
     "la_metro_translations.management.commands.batch_extract"
@@ -30,6 +38,15 @@ PATCH_EXTRACT_RESET_DB = (
     ".Command.reset_db_connections"
 )
 
+PATCH_CONVERT_DOCS_CONVERTER = (
+    "la_metro_translations.management.commands.convert_docs"
+    ".DocumentTranslationConverter"
+)
+
+PATCH_TRANSLATE_SERVICE = (
+    "la_metro_translations.management.commands.batch_translate.get_translation_service"
+)
+
 
 @pytest.mark.django_db
 class TestBatchTranslateCommand:
@@ -43,6 +60,17 @@ class TestBatchTranslateCommand:
     def no_reset_db(self):
         with patch(PATCH_TRANSLATE_RESET_DB):
             yield
+
+    @pytest.fixture(autouse=True)
+    def mock_translate_service(self, document_content):
+        with patch(PATCH_TRANSLATE_SERVICE) as mock_service:
+            mock_service.return_value.metered_batch_translate.return_value = [
+                {
+                    "document_id": str(document_content.document.document_id),
+                    "markdown": "translated text",
+                }
+            ]
+            yield mock_service
 
     @pytest.mark.parametrize("approval_status", ["waiting", "approved"])
     def test_creates_translations_with_correct_approval_status(
@@ -202,3 +230,159 @@ class TestBatchExtractCommand:
         run_command("batch_extract")
 
         mock_call_command.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestConvertDocsCommand:
+    """
+    Tests for the convert_docs management command.
+
+    This focuses on how the command creates RTFs for all DocumentTranslations with out-of-date RTFs,
+    and PDFs for all non-English DocumentTranslations with out-of-date PDFs.
+    """
+
+    @pytest.fixture
+    def doc_id_counter(self):
+        counter = itertools.count(1)
+        return lambda: next(counter)
+
+    @pytest.fixture
+    def make_translation(self, doc_id_counter):
+        def _make(language="spa"):
+            doc = DocumentFactory(document_id=doc_id_counter())
+            content = DocumentContentFactory(document=doc)
+            return DocumentTranslationFactory(
+                document_content=content, language=language
+            )
+
+        return _make
+
+    def _set_updated_at(self, obj, dt):
+        type(obj).objects.filter(pk=obj.pk).update(updated_at=dt)
+        obj.refresh_from_db()
+
+    def _make_translation_file(self, translation, fmt, updated_at=None):
+        file = TranslationFile.objects.create(
+            document_translation=translation, format=fmt
+        )
+        if updated_at is not None:
+            TranslationFile.objects.filter(pk=file.pk).update(updated_at=updated_at)
+        return file
+
+    def _mock_converter(self):
+        return patch(PATCH_CONVERT_DOCS_CONVERTER)
+
+    def test_rtf_created_only_for_translations_without_up_to_date_rtf(
+        self, make_translation
+    ):
+        """
+        Only translations missing an RTF or with an outdated RTF (file.updated_at <
+        translation.updated_at) should be processed. Translations with a current RTF
+        must be skipped.
+        """
+        now = datetime.now()
+        past = now - timedelta(hours=1)
+
+        make_translation()  # creates translation missing an RTF
+
+        outdated_rtf = make_translation()  # RTF exists but is stale
+        self._set_updated_at(outdated_rtf, now)
+        self._make_translation_file(outdated_rtf, "rtf", updated_at=past)
+
+        up_to_date = make_translation()  # RTF is current
+        self._set_updated_at(up_to_date, past)
+        self._make_translation_file(up_to_date, "rtf", updated_at=now)
+
+        with self._mock_converter() as MockConverter, patch.object(
+            Command, "bulk_create_translation_files"
+        ):
+            mock_instance = MockConverter.return_value
+            mock_instance.convert_to_rtf.return_value = MagicMock()
+            mock_instance.convert_to_pdf.return_value = MagicMock()
+            run_command("convert_docs")
+
+        assert mock_instance.convert_to_rtf.call_count == 2
+
+    def test_pdf_created_only_for_non_english_translations_without_up_to_date_pdf(
+        self, make_translation
+    ):
+        """
+        PDFs should only be created for non-English translations that are missing a
+        PDF or have an outdated one. English translations and those with a current PDF
+        must be skipped.
+
+        This test guards against the exclude() multi-argument bug where
+        .exclude(pk__in=..., language="eng") only excluded rows matching BOTH
+        conditions simultaneously, causing the queryset to return nearly all rows.
+        """
+        now = datetime.now()
+        past = now - timedelta(hours=1)
+
+        make_translation(language="eng")  # always skip eng, even without a PDF
+
+        make_translation(language="spa")  # creates translation missing a PDF
+
+        outdated = make_translation(language="zho-cn")  # PDF exists but is stale
+        self._set_updated_at(outdated, now)
+        self._make_translation_file(outdated, "pdf", updated_at=past)
+
+        up_to_date = make_translation(language="kor")  # PDF is current
+        self._set_updated_at(up_to_date, past)
+        self._make_translation_file(up_to_date, "pdf", updated_at=now)
+
+        with self._mock_converter() as MockConverter, patch.object(
+            Command, "bulk_create_translation_files"
+        ):
+            mock_instance = MockConverter.return_value
+            mock_instance.convert_to_rtf.return_value = MagicMock()
+            mock_instance.convert_to_pdf.return_value = MagicMock()
+            run_command("convert_docs")
+
+        assert mock_instance.convert_to_pdf.call_count == 2
+
+    def test_no_files_created_when_all_are_up_to_date(self, make_translation):
+        """
+        When every translation already has a current RTF and PDF, no converter calls
+        should be made and bulk_create should not be invoked.
+        """
+        now = datetime.now()
+        past = now - timedelta(hours=1)
+
+        non_eng = make_translation(language="spa")
+        self._set_updated_at(non_eng, past)
+        self._make_translation_file(non_eng, "rtf", updated_at=now)
+        self._make_translation_file(non_eng, "pdf", updated_at=now)
+
+        eng = make_translation(language="eng")
+        self._set_updated_at(eng, past)
+        self._make_translation_file(eng, "rtf", updated_at=now)
+
+        with self._mock_converter() as MockConverter, patch.object(
+            Command, "bulk_create_translation_files"
+        ) as mock_bulk_create:
+            mock_instance = MockConverter.return_value
+            run_command("convert_docs")
+
+        mock_instance.convert_to_rtf.assert_not_called()
+        mock_instance.convert_to_pdf.assert_not_called()
+        mock_bulk_create.assert_not_called()
+
+    def test_convert_doc_single_creates_rtf_and_pdf_for_non_english(
+        self, make_translation
+    ):
+        """
+        When called with --document_translation <id> for a non-English translation,
+        the command should create both an RTF and a PDF.
+        """
+        translation = make_translation(language="spa")
+
+        with self._mock_converter() as MockConverter, patch.object(
+            Command, "bulk_create_translation_files"
+        ):
+            mock_instance = MockConverter.return_value
+            mock_instance.convert_to_rtf.return_value = MagicMock()
+            mock_instance.convert_to_pdf.return_value = MagicMock()
+            run_command("convert_docs", document_translation=translation.pk)
+
+        mock_instance.convert_to_rtf.assert_called_once()
+        mock_instance.convert_to_pdf.assert_called_once()


### PR DESCRIPTION
## Overview

This pr eliminates some more issues with the conversion process. Namely, it deals with the timeout that used to also happen during batch extraction and conversion, and the incorrect querying of non-english, out of date translation files.

- Connects #36

- [x] Includes a test

## Testing Instructions

- Confirm that tests passed and make sense (s/o claude for those)
- Confirm [this run of the github action workflow](https://github.com/datamade/la-metro-translations/actions/runs/27634726546/job/81718757392) completed and doesn't try to make ~15k pdfs
