### PR TITLE
Render images in RTFs

### DIFF
--- a/la_metro_translations/services/conversion.py
+++ b/la_metro_translations/services/conversion.py
@@ -1,5 +1,8 @@
+import base64
 import io
 import os
+import re
+import tempfile
 import pypandoc
 
 from weasyprint import HTML
@@ -62,10 +65,34 @@ class DocumentTranslationConverter:
             document_translation=self.doc_translation, format="pdf", file=django_file
         )
 
+    def _image_uri_to_tempfile(self, media_type: str, b64data: str) -> str:
+        """Decode a base64 image URI to a temporary file, returning its path."""
+        img_bytes = base64.b64decode(b64data)
+        tmp = tempfile.NamedTemporaryFile(suffix=f".{media_type}", delete=False)
+        tmp.write(img_bytes)
+        tmp.close()
+        return tmp.name
+
     def convert_to_rtf(self) -> TranslationFile:
         md_text = self.doc_translation.markdown or ""
+        temp_files = []
 
         try:
+            # RTF embeds images as hex, but pandoc only handles file paths — not
+            # base64 data URIs. Decode each URI to a temp file so pandoc can read it.
+            pattern = r"!\[.*?\]\(data:image/(\w+);base64,([^)]+)\)"
+
+            def replace_with_tempfile(match):
+                media_type = match.group(1)
+                b64data = match.group(2)
+                path = self._image_uri_to_tempfile(media_type, b64data)
+                temp_files.append(path)
+                # Use empty alt text so pandoc doesn't emit the filename as a
+                # visible text paragraph below the embedded \pict block.
+                return f"![]({path})"
+
+            md_text = re.sub(pattern, replace_with_tempfile, md_text)
+
             output = pypandoc.convert_text(
                 md_text, to="rtf", format="markdown-yaml_metadata_block"
             )
@@ -76,9 +103,14 @@ class DocumentTranslationConverter:
             )
         except Exception as e:
             raise DocumentTranslationConverterError(f"Conversion failed: {e}")
+        finally:
+            for path in temp_files:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
 
         filename = self.doc_translation.document_content.document.title
-        content_type = "application/rtf"
         language = self.doc_translation.language
 
         # Add encoding strings to make sure file renders correctly
@@ -95,7 +127,7 @@ class DocumentTranslationConverter:
             file=out_io,
             field_name="file",
             name=f"{filename}_{language}.rtf",
-            content_type=content_type,
+            content_type="application/rtf",
             size=out_io.getbuffer().nbytes,
             charset="utf-8",
         )

--- a/la_metro_translations/services/conversion.py
+++ b/la_metro_translations/services/conversion.py
@@ -32,6 +32,9 @@ class DocumentTranslationConverter:
     def convert_to_pdf(self) -> TranslationFile:
         md_text = self.doc_translation.markdown or ""
 
+        # Strip alt text.
+        md_text = re.sub(r"!\[[^]]+\]", "![]", md_text)
+
         try:
             # Pypandoc requires PDFs to be written to the filesystem so
             # we can first convert the markdown to HTML and then use


### PR DESCRIPTION
## Overview

This PR allows us to write images to RTFs by way of a temporary file. This is because pandoc wants a file path to read. 

It also includes a small fix to remove the alt text that was showing up under the logo image in PDFs.

Closes #30

### Notes

RTF images will not appear on Apple software like Pages and TextEdit. See discussion in #30.


## Testing Instructions

- Run a document conversion of a Regular Board Meeting report and take a look.