### PR TITLE
Add UI info about when translation files are created

### DIFF
--- a/la_metro_translations/models.py
+++ b/la_metro_translations/models.py
@@ -395,12 +395,12 @@ class DocumentTranslation(AdminDisplayMixin, models.Model):
             for f in self.files.all():
                 files_btns += (
                     "<a class='button'"
-                    "style='width: stretch; font-weight: bold; text-align: center;'"
+                    "style='flex: 1; font-weight: bold; text-align: center;'"
                     f"target='_blank' href='{f.get_file_url()}'>{f.format.upper()}</a>"
                 )
 
             return format_html(
-                "<div style='display: flex; justify-content: space-between'>{}</div>",
+                "<div style='display: flex; gap: 0.5rem;'>{}</div>",
                 mark_safe(files_btns),
             )
 

--- a/la_metro_translations/models.py
+++ b/la_metro_translations/models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.utils.formats import date_format
 
 from modelcluster.fields import ParentalKey
 from modelcluster.models import ClusterableModel
@@ -390,6 +391,17 @@ class DocumentTranslation(AdminDisplayMixin, models.Model):
     language_display.short_description = "Language"
 
     def file_formats_display(self):
+        latest_file = self.files.order_by("-updated_at").first()
+        conversion_date = latest_file.updated_at if latest_file else None
+        conversion_date_str = (
+            date_format(conversion_date, "N j, Y, P") if conversion_date else None
+        )
+        conversion_message = (
+            f"Generated {conversion_date_str}"
+            if conversion_date_str
+            else "No PDF or RTF files have been generated for this translation."
+        )
+
         if getattr(self, "files", False):
             files_btns = ""
             for f in self.files.all():
@@ -400,8 +412,10 @@ class DocumentTranslation(AdminDisplayMixin, models.Model):
                 )
 
             return format_html(
-                "<div style='display: flex; gap: 0.5rem;'>{}</div>",
+                "<div style='display: flex; gap: 0.5rem;'>{}</div>"
+                "<div class='help' style='margin-top: .5rem'>{}</div>",
                 mark_safe(files_btns),
+                conversion_message,
             )
 
         return mark_safe(


### PR DESCRIPTION
## Overview

As discussed in #59, no info is conveyed to user about when files are created, though this is a separate step from translation. Ideally in production, the dates are the same, but it's potentially useful to surface them both for development purposes and as a possible sign if something is not working in the production pipeline. 

Closes #63

### Notes

Also includes a small fix to how the file buttons render.

### Testing

- Look at the File Formats panel for a translation that has files, and for one with no files.
- Run `convert_docs --document_translation <id>` for a translation with an existing file and see if the date updates in Wagtail above the file buttons.