### PR TITLE
Standardize document headers

### DIFF
--- a/la_metro_translations/services/ocr.py
+++ b/la_metro_translations/services/ocr.py
@@ -122,16 +122,18 @@ class MistralOCRService:
     @staticmethod
     def process_pages(pages: List[dict], document_type: str) -> str:
         """
-        Reinserts tables, images, and links into the markdown of each page.
+        Formats all headers to be the same level.
+        Then reinserts tables, images, and links into the markdown of each page.
         """
 
         doc_text = ""
 
         for page in pages:
-            markdown = page["markdown"]
-
             # Unescaped dollar signs cause unintended math formatting
-            markdown = markdown.replace("$", "\\$")
+            raw_markdown = page["markdown"].replace("$", "\\$")
+
+            # Format all markdown headers to be h3 level
+            markdown = re.sub(r"^#{1,6}\s+", "### ", raw_markdown, flags=re.MULTILINE)
 
             # Insert extracted tables, images, and links
             for table in page["tables"]:


### PR DESCRIPTION
## Overview

This pr changes all markdown headers within extracted document contents to be the same level `###` in order to standardize their appearance in final documents.

Closes #51

### Notes

The batch jobs I tried setting up for this app were queued for far too long for just a few documents, so I manually ran our single document processes on the review app. Because of this, the only processed document is the Regular Board Meeting agenda, processed into Spanish.

This process still uses the same method edited in this pr, but I can process more if we feel like that's needed.

## Testing Instructions

- Check out [this Regular Board Meeting agenda](https://la-metro-tra-patch-form-38aagc.herokuapp.com/document/edit/10/) (log in using creds in bitwarden for review apps)
- Look at its markdown content and translation
  - Confirm that any markdown headers have been standardized to all be `###` level
